### PR TITLE
Tidy develop

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                 <p>
                     <a href="https://deltachat.github.io/webxdc_docs/">guide book</a>
                     <br>
-                    <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/draft/webxdc-dev-reference.md">reference</a>
+                    <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/draft/webxdc-dev-reference.md">developer reference</a>
                 </p>
             </div>
             <div class="column is-two-thirds">

--- a/index.html
+++ b/index.html
@@ -116,13 +116,13 @@
             </div>
             <div class="column is-two-thirds">
                 <h2 class="subtitle">
-                    source code for examples
+                    sample code
                 </h2>
                 <p>
-                    you can find the above examples (and more) at <a href="https://github.com/webxdc">github.com/webxdc</a> and are welcome to improve or <b>use them as a template</b> for your own, maybe far better ideas ❤️
-                    <br><br>
-                    if you prefer to start from scratch,
-                    you can clone the repo  <a href="https://github.com/webxdc/hello">github.com/webxdc/hello</a>
+                    the simplest example is our <a href="https://github.com/webxdc/hello">Hello</a>, which is useful when starting from scratch.
+                </p>
+                <p>
+                    find sources for the above examples and more at our <a href="https://github.com/webxdc">GitHub organization</a> or on the <a href="https://github.com/topics/webxdc">webxdc topic</a>. be welcome to improve them or use them as a template for your own ideas for your own ideas ❤️
                 </p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -121,8 +121,13 @@
                 <p>
                     the simplest example is our <a href="https://github.com/webxdc/hello">Hello</a>, which is useful when starting from scratch.
                 </p>
+                <br>
                 <p>
-                    find sources for the above examples and more at our <a href="https://github.com/webxdc">GitHub organization</a> or on the <a href="https://github.com/topics/webxdc">webxdc topic</a>. be welcome to improve them or use them as a template for your own ideas for your own ideas ❤️
+                    find sources for the above examples and more at our <a href="https://github.com/webxdc">GitHub organization</a> or on the <a href="https://github.com/topics/webxdc">webxdc topic</a>.
+                </p>
+                <br>
+                <p>
+                    be welcome to improve them or use them as a template for your own ideas for your own ideas ❤️
                 </p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                     sample code
                 </h2>
                 <p>
-                    the simplest example is our <a href="https://github.com/webxdc/hello">Hello</a>, which is useful when starting from scratch.
+                    the simplest example is <a href="https://github.com/webxdc/hello">Hello</a>, which is useful when starting from scratch.
                 </p>
                 <br>
                 <p>

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
                 </p>
                 <br>
                 <p>
-                    find sources for the above examples and more at our <a href="https://github.com/webxdc">GitHub organization</a> or on the <a href="https://github.com/topics/webxdc">webxdc topic</a>.
+                    find sources for the above examples and more on the <a href="https://github.com/webxdc">repository list</a> or on the <a href="https://github.com/topics/webxdc">webxdc topic</a>.
                 </p>
                 <br>
                 <p>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
                 </p>
                 <br>
                 <p>
-                    be welcome to improve them or use them as a template for your own ideas for your own ideas ❤️
+                    be welcome to improve or use these as templates for your own ideas ❤️
                 </p>
             </div>
         </div>


### PR DESCRIPTION
This uses descriptive text instead of the URL for link anchors, and focuses on the simpler examples to start.