### PR TITLE
do not let screenreaders read "Screenshot" repeatedly

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                 <div class="smartphone">
                     <video class="content" autoplay muted loop playsinline>
                         <source src="assets/deltagif.mp4" type="video/mp4">
-                        <img class="content" alt="Screenshot" src="assets/screenshots/tower-builder.png">
+                        <img class="content" alt="" src="assets/screenshots/tower-builder.png">
                     </video>
                 </div>
 
@@ -62,51 +62,51 @@
 
         <div class="has-text-centered">
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/tower-builder.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/tower-builder.png"></div>
                 <div><a href="https://github.com/webxdc/tower-builder/releases/download/1.0.0/tower-builder.xdc">download<br><code>tower.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/hextris.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/hextris.png"></div>
                 <div><a href="https://github.com/webxdc/hextris/releases/download/1.2.1/hextris.xdc">download<br><code>hextris.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/chess.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/chess.png"></div>
                 <div><a href="https://github.com/webxdc/ChessBoard.xdc/releases/download/1.0.0/chess.xdc">download<br><code>chess.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/othello.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/othello.png"></div>
                 <div><a href="https://github.com/webxdc/Othello.xdc/releases/download/1.0.0/othello.xdc">download<br><code>othello.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/stackup.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/stackup.png"></div>
                 <div><a href="https://github.com/webxdc/StackUp.xdc/releases/download/1.0.0/stackup.xdc">download<br><code>stackup.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/2048.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/2048.png"></div>
                 <div><a href="https://github.com/webxdc/2048.xdc/releases/download/1.0.0/2048.xdc">download<br><code>2048.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/tictactoe.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/tictactoe.png"></div>
                 <div><a href="https://github.com/webxdc/tictactoe.xdc/releases/download/9/tictactoe.xdc">download<br><code>tictactoe.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/poll.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/poll.png"></div>
                 <div><a href="https://github.com/webxdc/webxdc-poll/releases/download/1.0.0/webxdc-poll.xdc">download<br><code>poll.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/checklist.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/checklist.png"></div>
                 <div><a href="https://github.com/webxdc/webxdc-checklist/releases/download/0.0.1/checklist.xdc">download<br><code>checklist.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/corkboard.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/corkboard.png"></div>
                 <div><a href="https://github.com/webxdc/webxdc-corkboard/releases/download/0.0.1/corkboard.xdc">download<br><code>corkboard.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/draw.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/draw.png"></div>
                 <div><a href="https://github.com/webxdc/draw.xdc/releases/download/1.0.0/draw.xdc">download<br><code>draw.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="Screenshot" src="assets/screenshots/editor.png"></div>
+                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/editor.png"></div>
                 <div>under<br>construction ...</div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
                 <div class="smartphone">
                     <video class="content" autoplay muted loop playsinline>
                         <source src="assets/deltagif.mp4" type="video/mp4">
-                        <img class="content" alt="" src="assets/screenshots/tower-builder.png">
+                        <img class="content" aria-hidden="true" src="assets/screenshots/tower-builder.png">
                     </video>
                 </div>
 
@@ -62,51 +62,51 @@
 
         <div class="has-text-centered">
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/tower-builder.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/tower-builder.png"></div>
                 <div><a href="https://github.com/webxdc/tower-builder/releases/download/1.0.0/tower-builder.xdc">download<br><code>tower.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/hextris.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/hextris.png"></div>
                 <div><a href="https://github.com/webxdc/hextris/releases/download/1.2.1/hextris.xdc">download<br><code>hextris.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/chess.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/chess.png"></div>
                 <div><a href="https://github.com/webxdc/ChessBoard.xdc/releases/download/1.0.0/chess.xdc">download<br><code>chess.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/othello.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/othello.png"></div>
                 <div><a href="https://github.com/webxdc/Othello.xdc/releases/download/1.0.0/othello.xdc">download<br><code>othello.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/stackup.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/stackup.png"></div>
                 <div><a href="https://github.com/webxdc/StackUp.xdc/releases/download/1.0.0/stackup.xdc">download<br><code>stackup.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/2048.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/2048.png"></div>
                 <div><a href="https://github.com/webxdc/2048.xdc/releases/download/1.0.0/2048.xdc">download<br><code>2048.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/tictactoe.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/tictactoe.png"></div>
                 <div><a href="https://github.com/webxdc/tictactoe.xdc/releases/download/9/tictactoe.xdc">download<br><code>tictactoe.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/poll.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/poll.png"></div>
                 <div><a href="https://github.com/webxdc/webxdc-poll/releases/download/1.0.0/webxdc-poll.xdc">download<br><code>poll.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/checklist.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/checklist.png"></div>
                 <div><a href="https://github.com/webxdc/webxdc-checklist/releases/download/0.0.1/checklist.xdc">download<br><code>checklist.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/corkboard.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/corkboard.png"></div>
                 <div><a href="https://github.com/webxdc/webxdc-corkboard/releases/download/0.0.1/corkboard.xdc">download<br><code>corkboard.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/draw.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/draw.png"></div>
                 <div><a href="https://github.com/webxdc/draw.xdc/releases/download/1.0.0/draw.xdc">download<br><code>draw.xdc</code></a></div>
             </div>
             <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" alt="" src="assets/screenshots/editor.png"></div>
+                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/editor.png"></div>
                 <div>under<br>construction ...</div>
             </div>
         </div>


### PR DESCRIPTION
the empty alt-attribute is still needed as otherwise
accessibility tools may read the item as "image without further description" or so