### PR TITLE
Link to cosmos

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
 
     <link rel="stylesheet" href="assets/bulma.min.css">
     <link rel="stylesheet" href="assets/index.css">
+    
+    <script defer src="https://cosmos.delta.chat/banner.js"></script>
+    <link rel="stylesheet" href="https://cosmos.delta.chat/banner.css" type="text/css" />
 </head>
 <body>
 <section style="padding-bottom: 2em;">


### PR DESCRIPTION
This adds a small banner to the bottom of the page similar to https://cosmos.delta.chat so that readers can easily be aware of and discover various sites related to Delta Chat.