### PR TITLE
revised webxdc.org entry page

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -22,11 +22,11 @@
       </nav>
 
       <h1>webxdc apps</h1>
-      
+
       <p>compatible with <a href="https://delta.chat">Delta Chat</a>, <a href="https://cheogram.com">Cheogram</a>, and <a href="https://monocles.eu/more/">Monocles</a></p>
-      
+
     </header>
-    
+
     <div id="apps">
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
                 <p>
                     no&nbsp;logins, no&nbsp;coins, no&nbsp;platforms&nbsp;🎉
                 </p>
+                <br/>
+                <br/>
 
             </div>
             <div class="column has-text-centered">
@@ -48,6 +50,42 @@
         </div>
     </section>
 
+    <section class="box hero is-warning">
+
+        <h2 class="title" id="dev">
+            develop and deploy apps in no time
+        </h2>
+        <div class="columns">
+            <div class="column">
+                <p><a href="https://docs.webxdc.org">webxdc developer docs</a> bundle all information relevant for webxdc development.</p>
+                <p style="margin:.6em 0;">
+                    <a href="https://docs.webxdc.org/spec/index.html">the stable webxdc specification</a>
+                    defines the `.xdc` web app container format and networking API
+                </p>
+                <p style="margin:.6em 0;">
+                <a href="https://docs.webxdc.org/shared_state/index.html">Sharing web application state</a> discusses theory and practise of programming offline-first decentralized web apps.
+                </p>
+
+                <p style="margin:.6em 0;">
+                <a href="https://delta.chat/en/2023-05-22-webxdc-security">Bringing E2E privacy to the Web</a> details the unique webxdc promise of web apps without tracking or platforms.</p>
+
+                <p><a href="https://webxdc.org/apps">Webxdc store</a> offers a curated set of stable webxdc apps submitted by 3rd parties
+                </p>
+                <br/>
+                <p>
+                    or watch a 42 second "just web apps" video to get started :)
+                </p>
+                <br>
+                <p>
+                    <video controls>
+                        <source src="assets/just-web-apps.mp4" type="video/mp4">
+                        <a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch video “just web apps“ on youtube</a>
+                    </video>
+                </p>
+            </div>
+        </div>
+    </section>
+
     <section class="box hero is-success">
         <div>
             <h2 class="title" id="try">
@@ -55,8 +93,13 @@
             </h2>
             <p>
                 <ul>
-                    <li><span class="fixed-width-emoji">📥</span> download an <code>.xdc</code> file</li>
-                    <li><span class="fixed-width-emoji">📎</span> attach or share it as a file to a chat <sup id="ref1"><a style="text-decoration: none" href="#note1">[*]</a></sup> </li>
+                    <li><span class="fixed-width-emoji">📥</span>
+        Ready your messenger (<a href="https://get.delta.chat">Delta Chat</a>,
+                   <a href="https://cheogram.com">Cheogram</a> or
+                   <a href="https://f-droid.org/en/packages/de.monocles.chat/">Monocles</a>)</li>
+                    <li><span class="fixed-width-emoji">📥</span>
+        download an <code>.xdc</code> file from below or checkout the full <a href="https://webxdc.org/apps">webxdc store</a></li>
+                    <li><span class="fixed-width-emoji">📎</span> attach or share it as a file to a chat</li>
                     <li><span class="fixed-width-emoji">🎉</span> everyone can hit the “start” button</li>
                 </ul>
             </p>
@@ -89,43 +132,6 @@
             </div>
         </div>
 
-        <p style="margin-top: 2rem;">
-            for more apps, <a href="https://webxdc.org/apps">browse our list</a>, send <code>Hi</code> to <code>xstore@testrun.org</code>,
-            or read our <a href="https://delta.chat/en/2023-08-11-xstore">everything-apps without platforms</a> blog post
-        </p>
-
-    </section>
-
-    <section class="box hero is-warning">
-
-        <h2 class="title" id="dev">
-            develop
-        </h2>
-        <div class="columns">
-            <div class="column">
-                <p>
-                    the smallest example is <a href="https://github.com/webxdc/hello">hello</a>, useful when starting from scratch.
-                </p>
-                <p style="margin:.6em 0;">
-                    read the <a href="https://docs.webxdc.org">webxdc docs</a> for more info, examples and specifications </p>
-                <p>
-                    or watch this 42 second "just web apps" video :)
-                </p>
-                <br>
-                <p>
-                    <video controls>
-                        <source src="assets/just-web-apps.mp4" type="video/mp4">
-                        <a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch video “just web apps“ on youtube</a>
-                    </video>
-                </p>
-            </div>
-        </div>
-    </section>
-    <section class="footnotes">
-        <sup id="note1"><a style="text-decoration: none" href="#ref1">[*]</a></sup>
-        you need a configured <a href="https://get.delta.chat">delta chat</a>;<br>
-        you may <b>scan this invitation code during setup</b> to obtain a limited test e-mail account and start to play :)<br>
-        <a href="DCACCOUNT:https://mailadm.try.webxdc.org/?t=90d_f7v5c5xrtntpkqe&n=try90d"><img src="assets/accounts-qr.png" style="padding-top:.2em;max-width:10em;"></a>
     </section>
 
 

--- a/index.html
+++ b/index.html
@@ -63,11 +63,11 @@
                     defines the `.xdc` web app container format and networking API
                 </p>
                 <p style="margin:.6em 0;">
-                <a href="https://docs.webxdc.org/shared_state/index.html">Sharing web application state</a> discusses theory and practise of programming offline-first decentralized web apps.
+                <a href="https://docs.webxdc.org/shared_state/index.html">Sharing web application state</a> discusses theory and practise of programming offline-first decentralized web apps
                 </p>
 
                 <p style="margin:.6em 0;">
-                <a href="https://delta.chat/en/2023-05-22-webxdc-security">Bringing E2E privacy to the Web</a> details the unique webxdc promise of web apps without tracking or platforms.</p>
+                <a href="https://delta.chat/en/2023-05-22-webxdc-security">Bringing E2E privacy to the Web</a> details the unique webxdc promise of web apps without tracking or platforms</p>
 
                 <p><a href="https://webxdc.org/apps">Webxdc store</a> offers a curated set of stable webxdc apps submitted by 3rd parties
                 </p>


### PR DESCRIPTION
- removes delta chat QR code and reliance on Delta as only webxdc supporting messenger 
- re-orders develop section to be the first section after the headline box
- puts several annotated links  into the develop section to allow more direct navigation and give an implicit overview of what webxdc is about 
- Streamline "trying it out" and point to "webxdc.org/apps" 

before merging https://github.com/webxdc/website/issues/54 needs to be fixed. 