### PR TITLE
simplify first intro sentence

### DIFF
--- a/src-docs/intro.md
+++ b/src-docs/intro.md
@@ -1,6 +1,8 @@
 # From online-HTTP to offline-first P2P web apps
 
-Webxdc is a P2P oriented container format for sharing and hosting HTML5 web apps in messenger chats. 
+Webxdc brings web apps to messenger chats,
+in a P2P oriented container format
+for HTML5, css, and javascript.
 The e-mail based [Delta Chat](https://delta.chat) 
 and the XMPP-based [Cheogram](https://cheogram.com) messengers 
 support [webxdc apps](https://webxdc.org/apps), which run on both messengers without any change. 

--- a/src-docs/intro.md
+++ b/src-docs/intro.md
@@ -2,7 +2,7 @@
 
 Webxdc brings web apps to messenger chats,
 in a P2P oriented container format
-for HTML5, css, and javascript.
+containing HTML5, CSS, and JavaScript.
 The e-mail based [Delta Chat](https://delta.chat) 
 and the XMPP-based [Cheogram](https://cheogram.com) messengers 
 support [webxdc apps](https://webxdc.org/apps), which run on both messengers without any change. 


### PR DESCRIPTION
While the first sentence currently summarizes very well what webxdc is to experienced web developers, it's a high threshold for self-taught people like me who don't follow every web development fashion. The term "P2P oriented container format for sharing and hosting HTML5 web apps" simply stopped me from reading ahead; I intuitively assumed that I'm not the target group and this documentation goes above my skills anyway.

I hope this simplification lowers the threshold without sacrificing the original goal of the sentence.