### PR TITLE
focused navigation

### DIFF
--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -20,6 +20,11 @@ a {
     margin: auto; /* this centers the box */
 }
 
+.box-buttons .column {
+    margin-left: .75em;
+    margin-right: .75em;
+}
+
 .box-buttons .column:last-child {
     margin-bottom: 1.5em; /* for other columns, margin is set in bulma.css */
 }

--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -75,8 +75,8 @@ a {
 /* smartphone border, credits to https://www.w3schools.com/howto/howto_css_devices.asp */
 .smartphone { /* The device with borders */
     position: relative;
-    width: 250px;
-    height: 512px;
+    width: 200px;
+    height: 410px;
     margin: auto;
     border: 10px black solid;
     border-top-width: 36px;

--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -34,6 +34,14 @@ a {
         margin-top: 1.5em;
         border-radius: 6px;
     }
+
+    .box-buttons .column:first-child {
+        margin-left: 0;
+    }
+
+    .box-buttons .column:last-child {
+        margin-right: 0;
+    }
 }
 
 .footnotes, .page-footer {

--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -9,13 +9,15 @@ a {
     text-decoration: underline;
 }
 
-.box {
+.box-topmost {
     max-width: 1024px;
     margin: auto; /* this centers the box */
+    border-radius: 0 0 6px 6px;
 }
 
-.box-topmost {
-    border-radius: 0 0 6px 6px;
+.box-buttons {
+    max-width: 1024px;
+    margin: auto; /* this centers the box */
 }
 
 @media screen and (min-width: 1048px) {
@@ -45,12 +47,6 @@ a {
 
 .page-footer a:hover {
     text-decoration: underline;
-}
-
-.fixed-width-emoji {
-    min-width: 3ch;
-    display: inline-block;
-    text-align: center;
 }
 
 
@@ -84,29 +80,6 @@ a {
     background: black;
 }
 
-
-/* download uses smaller smartphone */
-.download {
-    width: 160px;
-}
-@media screen and (max-width: 768px) {
-    .download {
-        width: 145px;
-    }
-}
-
-.download .smartphone {
-    width: 132px;
-    height: 269px;
-    border: 5px black solid;
-    border-top-width: 19px;
-    border-bottom-width: 19px;
-    border-radius: 14px;
-
-    margin-top: 2em;
-    margin-bottom: .3em;
-    box-shadow: 0 0 8px #555;
-}
 .smartphone:before { /* The horizontal line on the top of the device */
     width: 32px;
     height: 3px;
@@ -115,13 +88,4 @@ a {
     transform: translate(-50%, -50%);
     border-radius: 5px;
 }
-
-.download a {
-    text-decoration: none;
-}
-
-.download a:hover {
-    text-decoration: underline;
-}
-
 

--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -29,6 +29,11 @@ a {
     margin-bottom: 1.5em; /* for other columns, margin is set in bulma.css */
 }
 
+.box-buttons .column h2 {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
 @media screen and (min-width: 1048px) {
     .box-topmost {
         margin-top: 1.5em;

--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -20,6 +20,10 @@ a {
     margin: auto; /* this centers the box */
 }
 
+.box-buttons .column:last-child {
+    margin-bottom: 1.5em; /* for other columns, margin is set in bulma.css */
+}
+
 @media screen and (min-width: 1048px) {
     .box-topmost {
         margin-top: 1.5em;

--- a/website/index.html
+++ b/website/index.html
@@ -52,13 +52,13 @@
 
     <div class="box-buttons columns">
 
-        <section class="box column hero is-warning">
+        <section class="box column hero is-warning has-text-centered">
             <h2 class="title">
                 <a href="https://webxdc.org/docs">develop in no time</a>
             </h2>
         </section>
 
-        <section class="box column hero is-success">
+        <section class="box column hero is-success has-text-centered">
             <h2 class="title" >
                 <a href="https://webxdc.org/apps">try out apps</a>
             </h2>

--- a/website/index.html
+++ b/website/index.html
@@ -54,7 +54,7 @@
 
         <section class="box column hero is-warning has-text-centered">
             <h2 class="title">
-                <a href="https://webxdc.org/docs">develop in no time</a>
+                <a href="https://webxdc.org/docs">develop own app</a>
             </h2>
         </section>
 

--- a/website/index.html
+++ b/website/index.html
@@ -25,7 +25,7 @@
         <div class="columns has-text-centered-mobile is-vcentered">
             <div class="column">
                 <h1 class="title">
-                    <img style="width: 3em;" alt="Webxdc Logo" src="assets/icon.png"><br>
+                    <img style="width: 3.4em;" alt="Webxdc Logo" src="assets/icon.png"><br>
                     webxdc
                 </h1>
                 <h3 class="subtitle">

--- a/website/index.html
+++ b/website/index.html
@@ -51,86 +51,15 @@
     </section>
 
     <section class="box hero is-warning">
-
         <h2 class="title" id="dev">
-            develop and deploy apps in no time
+            <a href="https://webxdc.org/docs">develop in no time</a>
         </h2>
-        <div class="columns">
-            <div class="column">
-                <p><a href="https://docs.webxdc.org">webxdc developer docs</a> bundle all information relevant for webxdc development.</p>
-                <p style="margin:.6em 0;">
-                    <a href="https://docs.webxdc.org/spec/index.html">the stable webxdc specification</a>
-                    defines the <code>.xdc</code> web app container format and networking API
-                </p>
-                <p style="margin:.6em 0;">
-                <a href="https://docs.webxdc.org/shared_state/index.html">Sharing web application state</a> discusses theory and practise of programming offline-first decentralized web apps
-                </p>
-
-                <p style="margin:.6em 0;">
-                <a href="https://delta.chat/en/2023-05-22-webxdc-security">Bringing E2E privacy to the Web</a> details the unique webxdc promise of web apps without tracking or platforms</p>
-
-                <p><a href="https://webxdc.org/apps">Webxdc store</a> offers a curated set of stable webxdc apps submitted by 3rd parties
-                </p>
-                <br/>
-                <p>
-                    or watch a 42 second "just web apps" video to get started :)
-                </p>
-                <br>
-                <p>
-                    <video controls>
-                        <source src="assets/just-web-apps.mp4" type="video/mp4">
-                        <a href="https://www.youtube.com/watch?v=I1K4pBvb2pI">watch video “just web apps“ on youtube</a>
-                    </video>
-                </p>
-            </div>
-        </div>
     </section>
 
     <section class="box hero is-success">
-        <div>
             <h2 class="title" id="try">
-                try it out
+                <a href="https://webxdc.org/apps">try out apps</a>
             </h2>
-            <p>
-                <ul>
-                    <li><span class="fixed-width-emoji">📥</span>
-        Ready your messenger (<a href="https://get.delta.chat">Delta Chat</a>,
-                   <a href="https://cheogram.com">Cheogram</a> or
-                   <a href="https://f-droid.org/en/packages/de.monocles.chat/">Monocles</a>)</li>
-                    <li><span class="fixed-width-emoji">📥</span>
-        download an <code>.xdc</code> file from below or checkout the full <a href="https://webxdc.org/apps">webxdc store</a></li>
-                    <li><span class="fixed-width-emoji">📎</span> attach or share it as a file to a chat</li>
-                    <li><span class="fixed-width-emoji">🎉</span> everyone can hit the “start” button</li>
-                </ul>
-            </p>
-        </div>
-
-        <div class="has-text-centered">
-            <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/editor.png"></div>
-                <div><a href="https://codeberg.org/webxdc/editor/releases/">download<br><code>editor.xdc</code></a></div>
-            </div>
-            <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/calendar.png"></div>
-                <div><a href="https://codeberg.org/webxdc/calendar/releases/">download<br><code>calendar.xdc</code></a></div>
-            </div>
-            <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/checklist.png"></div>
-                <div><a href="https://codeberg.org/webxdc/checklist/releases/">download<br><code>checklist.xdc</code></a></div>
-            </div>
-            <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/tower-builder.png"></div>
-                <div><a href="https://github.com/webxdc/tower-builder/releases/latest/download/tower-builder.xdc">download<br><code>tower.xdc</code></a></div>
-            </div>
-            <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/reactle.png"></div>
-                <div><a href="https://github.com/DeltaZen/reactle/releases/latest/download/reactle.xdc">download<br><code>reactle.xdc</code></a></div>
-            </div>
-            <div class="is-pulled-left download">
-                <div class="smartphone"><img class="content" aria-hidden="true" src="assets/screenshots/2048.png"></div>
-                <div><a href="https://github.com/webxdc/2048/releases/download/v2.3.0/app.xdc">download<br><code>2048.xdc</code></a></div>
-            </div>
-        </div>
 
     </section>
 

--- a/website/index.html
+++ b/website/index.html
@@ -50,7 +50,7 @@
         </div>
     </section>
 
-    <div class="box-buttons columns">
+    <div class="box-buttons columns is-mobile">
 
         <section class="box column hero is-warning has-text-centered">
             <h2 class="title">

--- a/website/index.html
+++ b/website/index.html
@@ -69,8 +69,6 @@
 
 </main>
 <footer class="page-footer">
-    <img style="width: 3em;" alt="" src="assets/icon.png">
-    <br>
     <a href="https://delta.chat/en/imprint">imprint</a>
     |
     <a href="https://delta.chat/en/gdpr-website">privacy policy</a>

--- a/website/index.html
+++ b/website/index.html
@@ -50,18 +50,21 @@
         </div>
     </section>
 
-    <section class="box hero is-warning">
-        <h2 class="title" id="dev">
-            <a href="https://webxdc.org/docs">develop in no time</a>
-        </h2>
-    </section>
+    <div class="box-buttons columns">
 
-    <section class="box hero is-success">
-            <h2 class="title" id="try">
+        <section class="box column hero is-warning">
+            <h2 class="title">
+                <a href="https://webxdc.org/docs">develop in no time</a>
+            </h2>
+        </section>
+
+        <section class="box column hero is-success">
+            <h2 class="title" >
                 <a href="https://webxdc.org/apps">try out apps</a>
             </h2>
+        </section>
 
-    </section>
+    </div>
 
 
 </main>

--- a/website/index.html
+++ b/website/index.html
@@ -22,7 +22,7 @@
 <body>
 <main style="padding-bottom: 2em;">
     <section class="box box-topmost hero is-dark">
-        <div class="columns has-text-centered-mobile is-vcentered">
+        <div class="columns has-text-centered-mobile is-vcentered is-gapless">
             <div class="column">
                 <h1 class="title">
                     <img style="width: 3.4em;" alt="Webxdc Logo" src="assets/icon.png"><br>


### PR DESCRIPTION
this PR removes the "develop" and "try out" boxes and uses two equivalent buttons instead.

logo and smartphone sizes are adapted to make use of the new layout.

moreover, some now unused css classes are removed.

desktop / mobile layout:

<img width=350 src=https://github.com/webxdc/website/assets/9800740/a85673d0-5b84-4881-b6a9-64ed131b98ed> &nbsp; &nbsp; <img width=150 src=https://github.com/webxdc/website/assets/9800740/9689835a-c799-4172-b01c-2f633c5d1665>

