### PR TITLE
let the app store be end-user focused

### DIFF
--- a/website/apps/index.html
+++ b/website/apps/index.html
@@ -10,12 +10,6 @@
   </head>
   <body>
     <header>
-      <nav>
-        <a href="/">home</a>
-        <a href="https://webxdc.org/docs">develop</a>
-        <a href="https://codeberg.org/webxdc/xdcget/src/branch/main/SUBMIT.md">publish app</a>
-        <a href="https://support.delta.chat/c/webxdc/20">forum</a>
-      </nav>
 
       <h1>webxdc apps</h1>
 
@@ -25,5 +19,12 @@
 
     <div id="apps">
     </div>
+
+    <div id="footer">
+      <a href="https://support.delta.chat/c/webxdc/20">support forum</a>
+      <a href="https://webxdc.org/docs">develop apps</a>
+      <a href="https://codeberg.org/webxdc/xdcget/src/branch/main/SUBMIT.md">publish apps</a>
+    </div>
+
   </body>
 </html>

--- a/website/apps/index.html
+++ b/website/apps/index.html
@@ -4,12 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>webxdc apps</title>
-    <!-- TODO meta tags to be found by search engines -->
     <script src="./main.js" type="module"></script>
     <link rel="stylesheet" href="./simple.min.css" />
     <link rel="stylesheet" href="./styles.css" />
-
-    <script defer src="https://cosmos.delta.chat/banner.js"></script>
   </head>
   <body>
     <header>

--- a/website/apps/styles.css
+++ b/website/apps/styles.css
@@ -64,3 +64,13 @@
   font-size: 60%;
   opacity: 0.5;
 }
+
+#footer {
+  text-align: center;
+  margin-top: 3em;
+  margin-bottom: 2em;
+}
+
+#footer a {
+  padding: .5em;
+}


### PR DESCRIPTION
there is already a separation between end-user and devs on webxdc.org (with #68 even more focused), therefore, in the app store:

- move developer centric links down, devs will find them
- in the footer, start with forum (potentially useful for end-users), then dev-specific things
- remove dc cosmos, things are not dc centric here

![Screenshot 2024-02-12 at 15 14 13](https://github.com/webxdc/website/assets/9800740/c5f5e1c9-3215-4052-ac6e-2dff79068b2a)
