### PR TITLE
add examples for `sendUpdate`, `setUpdateListener`

### DIFF
--- a/src-docs/spec/sendUpdate.md
+++ b/src-docs/spec/sendUpdate.md
@@ -29,6 +29,21 @@ Send an update to all peers.
 - `descr`: short, human-readable description what this update is about.
   this is shown e.g. as a fallback text in an e-mail program.
 
+Example:
+
+```js
+window.webxdc.sendUpdate(
+  { payload: "Hello from Alice" },
+  "A 'hello' message"
+);
+
+// Peers can receive messages as such:
+window.webxdc.setUpdateListener((update) => {
+  console.log(update.payload);
+});
+// 'Hello from Alice' is printed in the console
+```
+
 All peers, including the sending one,
 will receive the update by the callback given to [`setUpdateListener()`](./setUpdateListener.html).
 

--- a/src-docs/spec/setUpdateListener.md
+++ b/src-docs/spec/setUpdateListener.md
@@ -43,8 +43,8 @@ const initialPendingUpdatesHandledPromise = window.webxdc.setUpdateListener(
     // such as applying a chess move to the board.
     myDocumentState = myDocumentUpdate;
 
-    const areMoreUpdatesPending = update.serial !== update.max_serial;
-    if (!areMoreUpdatesPending) {
+    const areAllUpdatesProcessed = update.serial === update.max_serial;
+    if (areAllUpdatesProcessed) {
       renderDocument();
     }
   }
@@ -59,8 +59,7 @@ function renderDocument() {
   document.body.innerText = myDocumentState;
 }
 
-// ...
-// Other peers, or you:
+// Peers can send  messages like this
 window.webxdc.sendUpdate({ payload: "Knight d3" }, "Bob made a move!");
 ```
 

--- a/src-docs/spec/setUpdateListener.md
+++ b/src-docs/spec/setUpdateListener.md
@@ -32,43 +32,28 @@ Each `update` which is passed to the callback comes with the following propertie
 Example:
 
 ```js
-let myDocumentState = localStorage.getItem("myDocumentState") ?? "";
-
-let initialPendingUpdatesHandled = false;
+let myDocumentState = "";
 const initialPendingUpdatesHandledPromise = window.webxdc.setUpdateListener(
   (update) => {
     // Remember that the listener is invoked for
     // your own `window.webxdc.sendUpdate()` calls as well!
 
-    applyDocumentUpdate(update.payload);
-    localStorage.setItem("myDocumentState", myDocumentState);
-    localStorage.setItem("lastHandledUpdateSerial", update.serial);
+    // Dummy document update logic.
+    // Yours might be more complex,
+    // such as applying a chess move to the board.
+    myDocumentState = myDocumentUpdate;
 
     const areMoreUpdatesPending = update.serial !== update.max_serial;
-    if (
-      !areMoreUpdatesPending &&
-      // We'll make the initial render when the promise resolves,
-      // because if there are no pending updates,
-      // the listener will not be invoked.
-      initialPendingUpdatesHandled
-    ) {
+    if (!areMoreUpdatesPending) {
       renderDocument();
     }
-  },
-  parseInt(localStorage.getItem("lastHandledUpdateSerial") ?? "0")
+  }
 );
 
 initialPendingUpdatesHandledPromise.then(() => {
-  initialPendingUpdatesHandled = true;
   renderDocument();
 });
 
-function applyDocumentUpdate(myDocumentUpdate) {
-  // Dummy `applyDocumentUpdate` logic.
-  // Yours might be more complex,
-  // such as applying a chess move to the board.
-  myDocumentState = myDocumentUpdate;
-}
 // Let's only call this when there are no pending updates.
 function renderDocument() {
   document.body.innerText = myDocumentState;


### PR DESCRIPTION
Closes https://github.com/webxdc/website/issues/60

~~Some might say that the setUpdateListener example is too convoluted, but you can't really showcase the usage of `serial` without this much code.~~
~~Plus, a briefer example is already shown in `sendUpdate()` docs.~~
Update: I simplified the example.

The code has been tested with the `webxdc-dev` tool,
and (mostly) fomatted with Prettier.