### PR TITLE
Fix .xdc creation example

### DIFF
--- a/src-docs/get_started.md
+++ b/src-docs/get_started.md
@@ -44,10 +44,10 @@ The following `index.html` shows a complete webxdc app, with an input field show
 </html>
 ```
 
-To package the app as a `.xdc` file, zip the directory containing the `index.html`:
+To package the app as a `.xdc` file, zip the directory containing `index.html` and any related files:
 
 ```shell
-zip -9 --recurse-paths "myapp.xdc" PATH_TO_DIR
+(cd PATH_TO_DIR && zip -9 --recurse-paths - *) > myapp.xdc
 ```
 
 Now it's possible to share the `myapp.xdc` file in any chat: recipients can hit "Start" to begin using the app to enter text in this input field and send updates to each other. 


### PR DESCRIPTION
The described process creates an invalid .xdc file.  if i have `index.html` in a directory `foo/`, and the previous command was run, the zipfile would contain `foo/index.html`.  But webXDC requires plain `index.html` in the zipfile.

The updated command creates the expected webxdc file structure (tested with zip 3.0-13 on debian)