### PR TITLE
update realtime API availability

### DIFF
--- a/src-docs/spec/joinRealtimeChannel.md
+++ b/src-docs/spec/joinRealtimeChannel.md
@@ -22,10 +22,7 @@ will throw an error.
 
 This API is experimental and may not be implemented by every messenger yet.
 Check if it is available with `window.webxdc.joinRealtimeChannel !== undefined`
- 
-For Delta Chat, you need at least version 1.46 to enable the feature
-in the settings under `Settings -> Advanced -> Experimental Features -> Realtime Webxdc Channels`.
-Without enabling the feature, the API is available but not working.
+(for Delta Chat, the API is available and enabled by default since 1.48)
 
 ## `realtimeChannel.setListener((data) => {})` 
 


### PR DESCRIPTION
Delta Chat has the API enabled by default in 1.48, so no need to dive into setting details here

the part is linked from <https://github.com/deltachat/deltachat-pages/pull/1002>