### PR TITLE
removing the `descr` parameter to webxdc.sendUpdate 

### DIFF
--- a/src-docs/spec/sendUpdate.md
+++ b/src-docs/spec/sendUpdate.md
@@ -1,7 +1,7 @@
 # sendUpdate
 
 ```js
-window.webxdc.sendUpdate(update, descr);
+window.webxdc.sendUpdate(update);
 ```
 
 Send an update to all peers.
@@ -25,9 +25,6 @@ Send an update to all peers.
     - `update.summary`: optional, short text, shown beside the app icon;
        it is recommended to use some aggregated value, e.g. "8 votes", "Highscore: 123".
        Do not add linebreaks; implementations will truncate the text at about 20 characters or less.
-
-- `descr`: short, human-readable description what this update is about.
-  this is shown e.g. as a fallback text in an e-mail program.
 
 All peers, including the sending one,
 will receive the update by the callback given to [`setUpdateListener()`](./setUpdateListener.html).

--- a/src-docs/webxdc.d.ts
+++ b/src-docs/webxdc.d.ts
@@ -89,9 +89,8 @@ interface Webxdc<T> {
   /**
    * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
    * @param update status update to send
-   * @param description short, human-readable description what this update is about. this is shown eg. as a fallback text in an email program.
    */
-  sendUpdate(update: SendingStatusUpdate<T>, description: string): void;
+  sendUpdate(update: SendingStatusUpdate<T>): void;
   /**
    * Send a message with file, text or both to a chat.
    * Asks user to what Chat to send the message to.


### PR DESCRIPTION
the `descr` parameter was never really used or useful. 
New apps should not use it and messengers can ignore it if it is specified. 
addresses part of #85