### PR TITLE
refine messenger spec

### DIFF
--- a/src-docs/faq/compat.md
+++ b/src-docs/faq/compat.md
@@ -1,21 +1,6 @@
 
 # Compatibility
 
-## Other APIs and Tags Usage Hints
-
-Webxdc apps run in a restricted environment, but the following practices are permitted:
-
-- `localStorage`, `sessionStorage`, `indexedDB`
-- `visibilitychange` events
-- `window.navigator.language`
-- `window.location.href` but you can not specify or assume anything
-  about the scheme or domain part of the url. 
-- internal links, such as `<a href="localfile.html">`
-- `mailto` links, such as `<a href="mailto:addr@example.org?body=...">`
-- `<meta name="viewport" ...>` is useful especially as webviews from different platforms have different defaults
-- `<input type="file">` allows importing of files for further
-  processing; see [`sendToChat()`](../spec/sendToChat.md) for a way to export files
-
 ### Discouraged Practises 
 
 - `document.cookie` is known not to work on desktop and iOS—use `localStorage` instead

--- a/src-docs/spec/format.md
+++ b/src-docs/spec/format.md
@@ -2,14 +2,15 @@
 ## Webxdc Container File Format
 
 - a Webxdc app is a **ZIP-file** with the extension `.xdc`
+
 - the ZIP-file MUST use the default compression methods as of RFC 1950,
   this is "Deflate" or "Store"
+
 - the ZIP-file MUST contain at least the file `index.html`
+
 - the ZIP-file MAY contain a `manifest.toml` and `icon.png` or
   `icon.jpg` files
-- if the webxdc app is started, `index.html` MUST be opened in a
-  [restricted webview](../faq/compat.html) that only allows accessing
-  resources from the ZIP-file.
+
 
 ### The manifest.toml File
 

--- a/src-docs/spec/messenger.md
+++ b/src-docs/spec/messenger.md
@@ -9,29 +9,26 @@ The same webxdc container file shared in two separate chat messages
 will be regarded as two separate "webxdc apps" 
 and the two apps can not communicate with, or even know about, each other. 
 
-### Webview Constraints for Running Apps
+### Webview Constraints
 
-When starting a web view for a webxdc app to run, messenger implementors:
+When starting a web view for a webxdc app to run, messenger implementors
 
-- MUST run the [webxdc container file](./format.md) in a constrained,
-  network-isolated webview that
-  MUST deny all forms of internet access.
-  Consequently, you do not need to offer "privacy" or "cookie" consent screens as
-  there is no way a webxdc app can implicitly transfer user data to the internet.
-  If you don't restrict internet access for web application
-  unsuspecting users may run apps
+- MUST serve all resources from the [webxdc container file](./format.md) 
+  to the webxdc application. 
+
+- MUST implement the [Webxdc Javascript API](api.md) 
+  and serve a `webxdc.js` file accordingly. 
+
+- MUST deny all forms of Internet access;
+  if you don't restrict internet access 
+  unsuspecting users may run 3rd party apps
   that leak data of private interactions to outside third parties.
-
-- MUST inject `webxdc.js` and implement the
-  [Webxdc Javascript API](api.md) so that messages are relayed and shown in chats.
+  See ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security)
+  which contains a deep discussion of the unique privacy guarantees of webxdc. 
 
 - MUST support `localStorage`, `sessionStorage` and `indexedDB`
-  and isolate them so they can not delete or modify
-  the data of other webxdc content.
 
-- MUST allow unrestricted use of DOM storage (local storage, indexed db and co),
-  but make sure it is scoped to each webxdc app so they can not delete or modify
-  the data of other webxdc content.
+- MUST isolate all storage and state of one webxdc app from any other 
 
 - MUST support `visibilitychange` events
 
@@ -46,12 +43,8 @@ When starting a web view for a webxdc app to run, messenger implementors:
 
 - MUST support `<meta name="viewport" ...>` is useful especially as webviews from different platforms have different defaults
 
-- MUST `<input type="file">` allows importing of files for further
-  processing; see [`sendToChat()`](../spec/sendToChat.md) for a way to export files
-
-In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security)
-Delta Chat developers discuss the unique privacy guarantees of webxdc,
-and which mitigations messengers using Chromium webviews need to implement to satisfy them.
+- MUST support `<input type="file">` to allow importing of files;
+  see [`sendToChat()`](../spec/sendToChat.md) for a way to export files. 
 
 
 ### UI Interactions in Chats
@@ -69,13 +62,15 @@ and which mitigations messengers using Chromium webviews need to implement to sa
   as webxdc application developers SHOULD NOT be encouraged to send long texts here.
 
 - A "Start" button MUST be offered that runs the webxdc app.
+  Note that there is no need to ask for "privacy" or "cookie" consent because 
+  there is no way a webxdc app can implicitly transfer user data to the internet.
 
 
 ### Example Messenger Implementations
 
-- [Android using Java](https://github.com/deltachat/deltachat-android/blob/master/src/org/thoughtcrime/securesms/WebxdcActivity.java)
+- [Delta Chat Android using Java](https://github.com/deltachat/deltachat-android/blob/master/src/org/thoughtcrime/securesms/WebxdcActivity.java)
 
-- [iOS using Swift](https://github.com/deltachat/deltachat-ios/blob/master/deltachat-ios/Controller/WebxdcViewController.swift)
+- [Delta Chat iOS using Swift](https://github.com/deltachat/deltachat-ios/blob/master/deltachat-ios/Controller/WebxdcViewController.swift)
 
-- [Desktop using TypeScript](https://github.com/deltachat/deltachat-desktop/blob/786b7514d69ffb723bbe6e706494852a2641bfcd/src/main/deltachat/webxdc.ts)
+- [Delta Chat Desktop using TypeScript](https://github.com/deltachat/deltachat-desktop/blob/786b7514d69ffb723bbe6e706494852a2641bfcd/src/main/deltachat/webxdc.ts)
 

--- a/src-docs/spec/messenger.md
+++ b/src-docs/spec/messenger.md
@@ -16,6 +16,7 @@ When starting a web view for a webxdc app to run, messenger implementors
 - MUST serve all resources from the [webxdc container file](./format.md) 
   to the webxdc application. 
 
+- on initial opening, MUST open root URL for the webview with `index.html` appended 
 - MUST implement the [Webxdc Javascript API](api.md) 
   and serve a `webxdc.js` file accordingly. 
 

--- a/src-docs/spec/messenger.md
+++ b/src-docs/spec/messenger.md
@@ -13,39 +13,63 @@ and the two apps can not communicate with, or even know about, each other.
 
 When starting a web view for a webxdc app to run, messenger implementors:
 
-- MUST run the [webxdc container file](./format.md) in a constrained, 
-  network-isolated webview that 
-  MUST deny all forms of internet access. 
-  If you don't do this
-  unsuspecting users may leak data of their private interactions to outside third parties.
-  You do not need to offer "privacy" or "cookie" consent screens as
+- MUST run the [webxdc container file](./format.md) in a constrained,
+  network-isolated webview that
+  MUST deny all forms of internet access.
+  Consequently, you do not need to offer "privacy" or "cookie" consent screens as
   there is no way a webxdc app can implicitly transfer user data to the internet.
+  If you don't restrict internet access for web application
+  unsuspecting users may run apps
+  that leak data of private interactions to outside third parties.
+
+- MUST inject `webxdc.js` and implement the
+  [Webxdc Javascript API](api.md) so that messages are relayed and shown in chats.
+
+- MUST support `localStorage`, `sessionStorage` and `indexedDB`
+  and isolate them so they can not delete or modify
+  the data of other webxdc content.
 
 - MUST allow unrestricted use of DOM storage (local storage, indexed db and co),
   but make sure it is scoped to each webxdc app so they can not delete or modify
   the data of other webxdc content.
 
-- MUST inject `webxdc.js` and implement the
-  [Webxdc Javascript API](api.md) so that messages are relayed and shown in chats.
+- MUST support `visibilitychange` events
 
-- MUST make sure the standard JavaScript API works as described at
-  [Other APIs and Tags Usage Hints](../faq/compat.md#other-apis-and-tags-usage-hints).
+- MUST support `window.navigator.language`
 
-In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security) 
+- MUST support `window.location.href` but you can not specify or assume anything
+  about the scheme or domain part of the url.
+
+- MUST support HTML links such as `<a href="localfile.html">`
+
+- MUST support `mailto` links, such as `<a href="mailto:addr@example.org?body=...">`
+
+- MUST support `<meta name="viewport" ...>` is useful especially as webviews from different platforms have different defaults
+
+- MUST `<input type="file">` allows importing of files for further
+  processing; see [`sendToChat()`](../spec/sendToChat.md) for a way to export files
+
+In ["Bringing E2E privacy to the web"](https://delta.chat/en/2023-05-22-webxdc-security)
 Delta Chat developers discuss the unique privacy guarantees of webxdc,
-and which mitigations messengers using Chromium webviews need to implement to satisfy them. 
+and which mitigations messengers using Chromium webviews need to implement to satisfy them.
+
 
 ### UI Interactions in Chats
 
 - Text from `update.info` SHOULD be shown in the chats
-  and tapping them should jump to their webxdc message
+  and tapping them SHOULD open the webxdc app directly.
+  If `update.href` was set then the webxdc app MUST
+  be started with the root URL for the webview with
+  the value of `update.href` appended.
 
-- The most recent text from `update.document` and `update.summary` SHOULD be shown inside the webxdc message,
+- The most recent text from `update.document`
+  and `update.summary` SHOULD be shown inside the webxdc message,
   together with name and icon.
   Only one line of text SHOULD be shown and truncation is fine
-  as webxdc devs SHOULD NOT be encouraged to send long texts here.
+  as webxdc application developers SHOULD NOT be encouraged to send long texts here.
 
-- A "Start" button SHOULD run the webxdc app.
+- A "Start" button MUST be offered that runs the webxdc app.
+
 
 ### Example Messenger Implementations
 


### PR DESCRIPTION
Moves some part from compat to the messenger spec, and clarifies and streamlines the language there. 