### PR TITLE
<a href=data:> does not guarantee a download dialog

### DIFF
--- a/src-docs/faq/compat.md
+++ b/src-docs/faq/compat.md
@@ -13,6 +13,8 @@
   e.g. with <https://babeljs.io>
 - `<a href="https://example.org/foo">` and other external links are blocked by definition;
   instead, embed content or use `mailto:` link to offer a way for contact
+- `<a href="data: or otherwise internal">` is not guaranteed to open a download dialog;
+  instead, use [`sendToChat()`](../spec/sendToChat.md) to export files.
 - features that require user permissions
   or are enabled through the [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy) may not work,
   Geolocation, Camera, Microphone etc.


### PR DESCRIPTION
webviews do not support the UI elements needed for `<a href=data:>` by default, otoh, probably hard to remove them on desktop.

not sure how much in use the method is at all, wei did not came over it until https://github.com/deltachat/deltachat-android/issues/3811

anyways, for now, say it is not guaranteed and point to the supported webxdc api.

