### PR TITLE
fix: turn app `<button>`s into `<a>`s

### DIFF
--- a/website/apps/main.js
+++ b/website/apps/main.js
@@ -27,9 +27,9 @@ const App = ({ app, toggleModal }) => {
   const subtitle = app.description.split('\n').shift();
 
   return html`
-    <button
+    <a
       class="app"
-      onClick=${() => toggleModal(app.app_id)}
+      href="#${app.app_id}"
       key=${app.app_id}>
       <img src=${xdcget_export + "/" + app.icon_relname} loading="lazy" alt="Icon for ${app.name} app" />
       <div class="props ellipse">


### PR DESCRIPTION
This allows Shift / Ctrl + Clicking them to open in new tab
and is overall more sensible with our `hashchange` approach.

A side effect of this is that the app list items
no longer change brightness on hover,
which could be considered a positive side effect by some.

Apparently the initial implementation of showing apps in a dialog
did not have the `hashchange` handler yet, so that was probably
the reason to use `<button>` instead of `<a>`:
https://github.com/webxdc/website/pull/99/changes/58d8e444a0423563e9316b6d97b18b9a9b5fd870.
The `hashchange` listener was added a few commits later:
https://github.com/webxdc/website/pull/99/changes/7b294dc62b8a045f7c13a600a5a9ab290ce1e074.

I have checked that clicking and opening the initial URL (like /website/apps/#wofwca-quake3) works.