### PR TITLE
fix: use native `<dialog>`

### DIFF
--- a/website/apps/main.js
+++ b/website/apps/main.js
@@ -47,11 +47,19 @@ downloading the actual webxdc file from the server.
 */
 const Dialog = ({app, modal, toggleModal}) => {
   const [subtitle, description] = [app.description.split('\n').shift(), app.description.split('\n').slice(1).join(' ')];
+  const ref = /** @type {import("react").RefObject<HTMLDialogElement>} */(useRef());
 
-  // Change the title when a dialog is open
-  if(modal === app.app_id) {
-    document.title = `webxdc apps: ${app.name}`;
-  }
+  useEffect(() => {
+    // Only show the modal that matches the app ID that was clicked.
+    if(modal === app.app_id) {
+      ref.current.showModal();
+      // Change the title when a dialog is open
+      document.title = `webxdc apps: ${app.name}`;
+      return () => {
+        ref.current.close();
+      };
+    }
+  }, [modal, app.app_id]);
 
   // Display the size of the webxdc apps in a more human readable format
   let size = `${(app.size/1000).toLocaleString(undefined, {maximumFractionDigits: 1})} kb`;
@@ -60,8 +68,7 @@ const Dialog = ({app, modal, toggleModal}) => {
   }
 
   return html`
-    <!-- Only show the modal that matches the app ID that was clicked -->
-    <div id=${app.app_id} role="dialog" aria-labelledby="${app.app_id}_label" aria-describedby="${app.app_id}_desc" aria-modal="true" class="${modal === app.app_id ? 'active' : 'hidden'}">
+    <dialog ref=${ref} id=${app.app_id} onClose=${() => toggleModal(false)} aria-labelledby="${app.app_id}_label" aria-describedby="${app.app_id}_desc">
       <div class="app-container">
         <img src="${xdcget_export + "/" + app.icon_relname}" loading="lazy" alt="Icon of ${app.name} app" />
         <div class="metadata">
@@ -92,7 +99,7 @@ const Dialog = ({app, modal, toggleModal}) => {
         </a>
         <button class="ghost" onClick=${() => toggleModal(false)}>Close</button>
       </div>
-    </div>
+    </dialog>
   `;
 };
 
@@ -237,11 +244,9 @@ const MainScreen = () => {
       ${searchResults &&
         searchResults.map((result) => html`<${App} app=${result.item} />`)}
     </div>
-    <div id="dialog_layer" class="dialogs">
-      <div class="dialog-backdrop ${modal ? 'active' : 'hidden'}">
-        ${searchResults && 
-          searchResults.map((result) => html`<${Dialog} app=${result.item} modal=${modal} toggleModal=${toggleModal} />`)}
-      </div>
+    <div>
+      ${searchResults && 
+        searchResults.map((result) => html`<${Dialog} app=${result.item} modal=${modal} toggleModal=${toggleModal} />`)}
     </div>
     <div id="footer">
       <a href="https://support.delta.chat/c/webxdc/20">support forum</a>

--- a/website/apps/styles.css
+++ b/website/apps/styles.css
@@ -151,51 +151,41 @@ button.ghost, .button.ghost {
   -------
 */
 
-.dialog-backdrop {
-  background: rgb(0 0 0 / 30%);
-  display: none;
-  position: fixed;
-  overflow-y: auto;
-  inset: 0;
-  z-index: 1;
-}
-
-.dialog-backdrop.active {
-  display: block;
-}
-
-[role=dialog] {
+dialog {
   font-size: 1rem;
-  display: none;
+  color: var(--text);
   padding: 2rem;
   background: var(--bg);
   min-height: 100vh;
+  margin: 0;
+  width: 100%;
+  border: none;
   gap: 1rem;
 }
 
-[role=dialog] .app-container {
+dialog .app-container {
   display: flex;
   gap: var(--padding);
 }
 
-[role=dialog] .button-container {
+dialog .button-container {
   display: flex;
   gap: var(--padding);
   width: 100%;
   flex-direction: column;
 }
 
-[role=dialog].active {
+dialog[open] {
   display: flex;
   flex-direction: column;
 }
 
-[role=dialog] .metadata {
+dialog .metadata {
   display: flex;
   flex-direction: column;
 }
 
-[role=dialog] .additional-info {
+dialog .additional-info {
   display: flex;
   flex-direction: column;
 }
@@ -260,12 +250,9 @@ button.ghost, .button.ghost {
     margin: .5rem;
   }
 
-  [role=dialog] {
-    display: none;
-    position: absolute;
-    top: 2rem;
-    left: 50vw;
-    transform: translateX( -50% );
+  dialog {
+    margin: auto;
+    margin-top: 2rem;
     min-width: calc(640px - (15px * 2));
     max-width: calc(640px - (15px * 2));
     min-height: auto;
@@ -273,7 +260,7 @@ button.ghost, .button.ghost {
     border-radius: var(--padding);
   }
 
-  [role=dialog] .button-container {
+  dialog .button-container {
     display: flex;
     gap: var(--padding);
     width: fit-content;
@@ -284,10 +271,6 @@ button.ghost, .button.ghost {
 @media (prefers-color-scheme: dark) {
   .app {
     border-color: #FFFFFF20;
-  }
-
-  .dialog-backdrop {
-    background: rgb(255 255 255 / 30%);
   }
 
   .search {


### PR DESCRIPTION
Most importantly, this allows closing the dialog with Escape.

A (positive?) side effect is that in the dark theme
when opening the dialog
we will darken the background instead of lightening it.

I have tested this on narrow screens and wide screens,
comparing side-by-side with the original version.
Everything should look almost the same, maybe except
for the backdrop.

This also fixes a small issue where the contents outside the dialog
were keyboard-interactive.
