### PR TITLE
feat: add "Try It" button for /apps

### DIFF
--- a/website/apps/main.js
+++ b/website/apps/main.js
@@ -69,6 +69,10 @@ const Dialog = ({app, modal, toggleModal}) => {
   }
 
   const tryItUrl = useMemo(() => {
+    if (!location.search.includes('tryIt')) {
+      return null;
+    }
+
     const url = new URL(tryItBaseUrl);
     url.hostname =
       "webapp-" +
@@ -115,7 +119,7 @@ const Dialog = ({app, modal, toggleModal}) => {
         <a href="${xdcget_export + "/" + app.cache_relname}" target="_blank" class="button">
           Add to Chat
         </a>
-        <a class="button" target="_blank" href="${tryItUrl}">Try it</a>
+        ${tryItUrl && html`<a class="button" target="_blank" href="${tryItUrl}">Try it</a>`}
         <button class="ghost" onClick=${() => toggleModal(false)}>Close</button>
       </div>
     </dialog>

--- a/website/apps/main.js
+++ b/website/apps/main.js
@@ -18,6 +18,7 @@ dayjs.extend(dayjs_plugin_localizedFormat);
 
 // without a trailing slash
 const xdcget_export = "https://apps.testrun.org";
+const tryItBaseUrl = "https://webxdc-try-it.xyz";
 
 /*
 Each <App> is implemented as a button that, when clicked, would show
@@ -67,6 +68,19 @@ const Dialog = ({app, modal, toggleModal}) => {
     size = `${(app.size/1000000).toLocaleString(undefined, {maximumFractionDigits: 1})} mb`;
   }
 
+  let tryItUrl = new URL(tryItBaseUrl);
+  tryItUrl.hostname =
+    "webapp-" +
+    app.app_id +
+    "-" +
+    app.tag_name.replaceAll(".", "-") +
+    "." +
+    tryItUrl.hostname;
+  const params = new URLSearchParams({
+    url: xdcget_export + "/" + app.cache_relname,
+  });
+  tryItUrl.hash = params.toString();
+
   return html`
     <dialog ref=${ref} id=${app.app_id} onClose=${() => toggleModal(false)} closedby="any" aria-labelledby="${app.app_id}_label" aria-describedby="${app.app_id}_desc">
       <div class="app-container">
@@ -97,6 +111,7 @@ const Dialog = ({app, modal, toggleModal}) => {
         <a href="${xdcget_export + "/" + app.cache_relname}" target="_blank" class="button">
           Add to Chat
         </a>
+        <a class="button" target="_blank" href="${tryItUrl.toString()}">Try it</a>
         <button class="ghost" onClick=${() => toggleModal(false)}>Close</button>
       </div>
     </dialog>

--- a/website/apps/main.js
+++ b/website/apps/main.js
@@ -68,18 +68,22 @@ const Dialog = ({app, modal, toggleModal}) => {
     size = `${(app.size/1000000).toLocaleString(undefined, {maximumFractionDigits: 1})} mb`;
   }
 
-  let tryItUrl = new URL(tryItBaseUrl);
-  tryItUrl.hostname =
-    "webapp-" +
-    app.app_id +
-    "-" +
-    app.tag_name.replaceAll(".", "-") +
-    "." +
-    tryItUrl.hostname;
-  const params = new URLSearchParams({
-    url: xdcget_export + "/" + app.cache_relname,
-  });
-  tryItUrl.hash = params.toString();
+  const tryItUrl = useMemo(() => {
+    const url = new URL(tryItBaseUrl);
+    url.hostname =
+      "webapp-" +
+      app.app_id +
+      "-" +
+      app.tag_name.replaceAll(".", "-") +
+      "." +
+      url.hostname;
+    const params = new URLSearchParams({
+      url: xdcget_export + "/" + app.cache_relname,
+    });
+    url.hash = params.toString();
+
+    return url.toString();
+  }, [app.app_id, app.cache_relname, app.tag_name]);
 
   return html`
     <dialog ref=${ref} id=${app.app_id} onClose=${() => toggleModal(false)} closedby="any" aria-labelledby="${app.app_id}_label" aria-describedby="${app.app_id}_desc">
@@ -111,7 +115,7 @@ const Dialog = ({app, modal, toggleModal}) => {
         <a href="${xdcget_export + "/" + app.cache_relname}" target="_blank" class="button">
           Add to Chat
         </a>
-        <a class="button" target="_blank" href="${tryItUrl.toString()}">Try it</a>
+        <a class="button" target="_blank" href="${tryItUrl}">Try it</a>
         <button class="ghost" onClick=${() => toggleModal(false)}>Close</button>
       </div>
     </dialog>


### PR DESCRIPTION
Hidden by default for now.

<img width="527" height="276" alt="image" src="https://github.com/user-attachments/assets/537d0482-bfa6-4558-9412-ad48e44c2d63" />


See <https://support.delta.chat/t/run-webxdc-apps-in-the-browser-we-added-try-it-button-to-the-app-store/4445?u=wofwca>.

I am committed to maintaining the <https://webxdc-try-it.xyz> site
for at least 2 years.
However, if this feature is liked it would be really nice
to do the deployment on some more "official" servers,
such as webxdc.org itself.
Luckily, the deployment isn't that hard.
See <https://github.com/DavidSM10/web-app-runner?tab=readme-ov-file#how-set-it-up-online>.

The reason we can't simply always show this button
is because the the `/apps` page is used by Delta Chat for Android
as the app picker ("Add Attachment"), where such a button doesn't make sense.
Also maybe Delta Touch does the same.

I suggest to act as follows:

1. Merge this.
2. On Delta Chat Android (and possibly Delta Touch (and iOS)),
   add a query (search) param `hideTryItButton` to the app picker's URL,
   so that the website's JS can read it and disable the "Try It" button.
3. Wait for sufficient deployment of the new Delta Chat version
   from the previous steps.
4. Enable the "Try It" button by default.
5. (later) deploy the "Try It" website on a webxdc.org subdomain,
   so that you don't have to hope that I don't get hit by a bus.

CC @davidsm10